### PR TITLE
fix: unexpected exception: InvalidCastException with "ForeignKeyConstraintDefinition"

### DIFF
--- a/src/SqlToCsharp/ColumnInfo.cs
+++ b/src/SqlToCsharp/ColumnInfo.cs
@@ -26,7 +26,7 @@ namespace SqlToCsharp
         private static int? FindPrimaryKeyConstraint(ColumnDefinition column, IList<ConstraintDefinition> tableConstraints)
         {
             var cons =
-                from uc in tableConstraints.OfType<>(UniqueConstraintDefinition)
+                from uc in tableConstraints.OfType<UniqueConstraintDefinition>()
                 from col in uc.Columns.Indexed()
                 where col.item.Column.MultiPartIdentifier.Identifiers.Last().Value == column.ColumnIdentifier.Value
                 select (int?)col.index;

--- a/src/SqlToCsharp/ColumnInfo.cs
+++ b/src/SqlToCsharp/ColumnInfo.cs
@@ -26,10 +26,10 @@ namespace SqlToCsharp
         private static int? FindPrimaryKeyConstraint(ColumnDefinition column, IList<ConstraintDefinition> tableConstraints)
         {
             var cons =
-				from uc in tableConstraints
-					where uc is UniqueConstraintDefinition
-				from col in ((UniqueConstraintDefinition)uc).Columns.Indexed()
-					where col.item.Column.MultiPartIdentifier.Identifiers.Last().Value == column.ColumnIdentifier.Value
+                from uc in tableConstraints
+                where uc is UniqueConstraintDefinition
+                from col in ((UniqueConstraintDefinition)uc).Columns.Indexed()
+                where col.item.Column.MultiPartIdentifier.Identifiers.Last().Value == column.ColumnIdentifier.Value
                 select (int?)col.index;
 
             return cons.FirstOrDefault();

--- a/src/SqlToCsharp/ColumnInfo.cs
+++ b/src/SqlToCsharp/ColumnInfo.cs
@@ -26,9 +26,10 @@ namespace SqlToCsharp
         private static int? FindPrimaryKeyConstraint(ColumnDefinition column, IList<ConstraintDefinition> tableConstraints)
         {
             var cons =
-                from UniqueConstraintDefinition uc in tableConstraints
-                from col in uc.Columns.Indexed()
-                where col.item.Column.MultiPartIdentifier.Identifiers.Last().Value == column.ColumnIdentifier.Value
+				from uc in tableConstraints
+					where uc is UniqueConstraintDefinition
+				from col in ((UniqueConstraintDefinition)uc).Columns.Indexed()
+					where col.item.Column.MultiPartIdentifier.Identifiers.Last().Value == column.ColumnIdentifier.Value
                 select (int?)col.index;
 
             return cons.FirstOrDefault();

--- a/src/SqlToCsharp/ColumnInfo.cs
+++ b/src/SqlToCsharp/ColumnInfo.cs
@@ -27,6 +27,7 @@ namespace SqlToCsharp
         {
             var cons =
                 from uc in tableConstraints.OfType<>(UniqueConstraintDefinition)
+                from col in uc.Columns.Indexed()
                 where col.item.Column.MultiPartIdentifier.Identifiers.Last().Value == column.ColumnIdentifier.Value
                 select (int?)col.index;
 

--- a/src/SqlToCsharp/ColumnInfo.cs
+++ b/src/SqlToCsharp/ColumnInfo.cs
@@ -26,9 +26,7 @@ namespace SqlToCsharp
         private static int? FindPrimaryKeyConstraint(ColumnDefinition column, IList<ConstraintDefinition> tableConstraints)
         {
             var cons =
-                from uc in tableConstraints
-                where uc is UniqueConstraintDefinition
-                from col in ((UniqueConstraintDefinition)uc).Columns.Indexed()
+                from uc in tableConstraints.OfType<>(UniqueConstraintDefinition)
                 where col.item.Column.MultiPartIdentifier.Identifiers.Last().Value == column.ColumnIdentifier.Value
                 select (int?)col.index;
 


### PR DESCRIPTION
If table has a foreign key, The InvalidCastException thrown.
ex:

    CREATE TABLE [dbo].[Table1] (
        [Id]          INT            IDENTITY (1, 1) NOT NULL,
        [SiteId]      INT            NOT NULL
        CONSTRAINT [PK__Table1__3214EC07A13796C8] PRIMARY KEY CLUSTERED ([Id] ASC),
        CONSTRAINT [FK_Table1_SiteId] FOREIGN KEY ([SiteId]) REFERENCES [dbo].[Table2] ([Id])
    );

I want the converter to ignore foreign keys.