### PR TITLE
feat: dotnet global tool and single executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Target Platform is `netcoreapp2.1`, however dependent package `Microsoft.SqlServer.TransactSql.ScriptDom` is for .NET Framework 4.6.
 this means SqlToCsharp guaranteed to run on Windows but not for other platform.
 
+> confirm work on linux-x64 with sample project.
+
 ## dotnet global tool
 
 Install.
@@ -21,6 +23,8 @@ dotnet-sqltocsharp ./samples/SqlToCsharpSampleDatabase ./samples/SqlToCsharpSamp
 
 Build Single executable.
 
+**windows**
+
 ```shell
 dotnet publish -c Release -r win-x64 -p:PublishSingleFile=true
 ```
@@ -29,4 +33,28 @@ run with samples.
 
 ```shell
 SqlToCsharp_win-x64.exe ./samples/SqlToCsharpSampleDatabase ./samples/SqlToCsharpSampleConsoleApp SqlToCsharpSample
+```
+
+**linux**
+
+confirm work on linux-x64 (ubuntu 18.04).
+
+```shell
+dotnet publish -c Release -r linux-x64 -p:PublishSingleFile=true
+```
+
+```shell
+./SqlToCsharp_linux-x64 ./samples/SqlToCsharpSampleDatabase ./samples/SqlToCsharpSampleConsoleApp SqlToCsharpSample
+```
+
+**linux**
+
+not-confirm on macos.
+
+```shell
+dotnet publish -c Release -r osx-x64 -p:PublishSingleFile=true
+```
+
+```shell
+./SqlToCsharp_osx-x64 ./samples/SqlToCsharpSampleDatabase ./samples/SqlToCsharpSampleConsoleApp SqlToCsharpSample
 ```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# SqlToCsharp
+
+Target Platform is `netcoreapp2.1`, however dependent package `Microsoft.SqlServer.TransactSql.ScriptDom` is for .NET Framework 4.6.
+this means SqlToCsharp guaranteed to run on Windows but not for other platform.
+
+## dotnet global tool
+
+Install.
+
+```shell
+dotnet tool install -g SqlToCsharp
+```
+
+Run with samples.
+
+```shell
+dotnet-sqltocsharp ./samples/SqlToCsharpSampleDatabase ./samples/SqlToCsharpSampleConsoleApp SqlToCsharpSample
+```
+
+## Single executable
+
+Build Single executable.
+
+```shell
+dotnet publish -c Release -r win-x64 -p:PublishSingleFile=true
+```
+
+run with samples.
+
+```shell
+SqlToCsharp_win-x64.exe ./samples/SqlToCsharpSampleDatabase ./samples/SqlToCsharpSampleConsoleApp SqlToCsharpSample
+```

--- a/src/SqlToCsharp/SqlToCsharp.csproj
+++ b/src/SqlToCsharp/SqlToCsharp.csproj
@@ -2,11 +2,45 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Version>1.0.0</Version>
+    <AssemblyVersion>$(Version)</AssemblyVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(PublishSingleFile)' != 'true'">
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackAsTool>true</PackAsTool>
+    <PackageId>SqlToCsharp</PackageId>
+    <ToolCommandName>dotnet-sqltocsharp</ToolCommandName>
+    <Authors>ufcpp</Authors>
+    <Company>ufcpp</Company>
+    <Copyright>ufcpp</Copyright>
+    <Description>A C# class generator from SQL CREATE TABLE Statements (SSDT)</Description>
+    <PackageProjectUrl>https://github.com/ufcpp/SqlToCsharp</PackageProjectUrl>
+    <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>sqlserver,parser,generator</PackageTags>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(PublishSingleFile)' == 'true'">
+    <AssemblyName>SqlToCsharp_$(RuntimeIdentifier)</AssemblyName>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishTrimmed>true</PublishTrimmed>
+    <IncludeSymbolsInSingleFile>true</IncludeSymbolsInSingleFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="14.0.3811.1" />
+    <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="15.0.4200.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\LICENSE">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR will offer 2 features.

1. pack as NuGet Global Tool when `dotnet build`.
1. generate Single Executable when publish as is.

Please see README for the detail.

## NOTICE

As NuGet Global Tool can be build only when netcoreapp, changed target from net472 to netcoreapp2.1. However `Microsoft.SqlServer.TransactSql.ScriptDom` is only for netframework.

This means this app is netcoreapp, but no guarantee to work on non-Windows environments, Linux and macOS.

confirm linux-x64 build work with Sample project.

## TODO

- [x] change target framework
- [x] add Dotnet Global Package support
- [x] add single executable support
- [x] add README
- [x] confirm dotnet core result is same as before
- [x] confirm Global Package generated result is same as before
- [x] confirm Single executable result is same as before
